### PR TITLE
draft-ristretto.md: Reformat header

### DIFF
--- a/draft-ristretto.md
+++ b/draft-ristretto.md
@@ -1,23 +1,27 @@
-% title    = "The Ristretto Elliptic Curve Groups"
-% abbrev   = "Ristretto"
-% category = "info"
-% docName  = "draft-ristretto-00"
-% area     = "Internet"
-% date     = 2018-07-25T23:00:00Z
-%
-% [[author]]
-% initials     = "Dr. "
-% surname      = "Who"
-% fullname     = "Peter Wilton Cushing"
-% role         = "editor"
-% organization = "The Timelords"
-%
-% [[author]]
-% initials     = "D.A.V.R.O.S."
-% surname      = "Davros"
-% fullname     = "Michael Wisher"
-% role         = "editor"
-% organization = "Imperial Daleks"
+%%%
+
+    title    = "The Ristretto Elliptic Curve Groups"
+    abbrev   = "Ristretto"
+    category = "info"
+    docName  = "draft-ristretto-00"
+    area     = "Internet"
+    date     = 2018-07-25T23:00:00Z
+    
+    [[author]]
+    initials     = "Dr. "
+    surname      = "Who"
+    fullname     = "Peter Wilton Cushing"
+    role         = "editor"
+    organization = "The Timelords"
+    
+    [[author]]
+    initials     = "D.A.V.R.O.S."
+    surname      = "Davros"
+    fullname     = "Michael Wisher"
+    role         = "editor"
+    organization = "Imperial Daleks"
+
+%%%
 
 .# Abstract
 

--- a/generated/draft-ristretto.html
+++ b/generated/draft-ristretto.html
@@ -556,8 +556,7 @@
 	  </span>
 	  <span class="country-name vcardline"></span>
 	</span>
-	<span class="vcardline">EMail: <a href="mailto:drwho@bbc.co.uk">drwho@bbc.co.uk</a></span>
-
+	
   </address>
 </div><div class="avoidbreak">
   <address class="vcard">
@@ -577,8 +576,7 @@
 	  </span>
 	  <span class="country-name vcardline"></span>
 	</span>
-	<span class="vcardline">EMail: <a href="mailto:davros@dalek.rs">davros@dalek.rs</a></span>
-
+	
   </address>
 </div>
 

--- a/generated/draft-ristretto.txt
+++ b/generated/draft-ristretto.txt
@@ -289,13 +289,13 @@ Authors' Addresses
    Peter Wilton Cushing (editor)
    The Timelords
 
-   Email: drwho@bbc.co.uk
-
 
    Michael Wisher (editor)
    Imperial Daleks
 
-   Email: davros@dalek.rs
+
+
+
 
 
 

--- a/generated/draft-ristretto.xml
+++ b/generated/draft-ristretto.xml
@@ -23,7 +23,7 @@
 <region></region>
 </postal>
 <phone></phone>
-<email>drwho@bbc.co.uk</email>
+<email></email>
 <uri></uri>
 </address>
 </author>
@@ -38,7 +38,7 @@
 <region></region>
 </postal>
 <phone></phone>
-<email>davros@dalek.rs</email>
+<email></email>
 <uri></uri>
 </address>
 </author>


### PR DESCRIPTION
Uses a header format with a slightly better Markdown rendering (i.e. on GitHub, not through mmark, which treats this as equivalent to the other form)